### PR TITLE
Make the multiplication code more compact

### DIFF
--- a/Roll a Ball/Assets/Scripts/Rotator.cs
+++ b/Roll a Ball/Assets/Scripts/Rotator.cs
@@ -7,6 +7,6 @@ public class Rotator : MonoBehaviour {
     // Update is called once per frame
     void Update ()
     {
-        transform.Rotate(new Vector3(15, 30, 45) * Time.deltaTime);
+        transform.Rotate(new Vector3(15, 30, 45)*Time.deltaTime);
     }
 }


### PR DESCRIPTION
Usually we don't use spaces around binary operators.